### PR TITLE
Run quota before apkd, connman and sailjaild

### DIFF
--- a/rpm/01-start-before-services.conf
+++ b/rpm/01-start-before-services.conf
@@ -1,0 +1,11 @@
+# The service runs quotacheck which makes fs (home) as read only for the
+# duration of the check. As a post exec task the quota is set then on.
+# Systemd does wait the main StartExec process either to report when it is
+# ready or, as in this case quotacheck does not report back to systemd and
+# the ready state is triggered by the process quiting. Therefore, the post
+# exec task is ran after quotacheck finishes and the service state is complete
+# after that step. Add here the list of services that are expected to write to
+# home, which should be run after this service completes its start and sets
+# the quota on.
+[Unit]
+Before=apkd.service connman.service sailjaild.service

--- a/rpm/quota.spec
+++ b/rpm/quota.spec
@@ -37,6 +37,7 @@ License: BSD and GPLv2 and GPLv2+
 URL: https://github.com/sailfishos/quota
 Source0: %{name}-%{version}.tar.gz
 Source1: quota_nld.service
+Source2: 01-start-before-services.conf
 
 BuildRequires: autoconf
 BuildRequires: automake
@@ -116,6 +117,9 @@ install -p -m644 -D %{SOURCE1} %{buildroot}/%{_unitdir}/quota_nld.service
 install -p -d %{buildroot}/%{_unitdir}/multi-user.target.wants/
 ln -s ../quota_nld.service %{buildroot}/%{_unitdir}/multi-user.target.wants/
 
+mkdir -p %{buildroot}/%{_unitdir}/quota@home.service.d
+install -p -m644 -D %{SOURCE2} %{buildroot}/%{_unitdir}/quota@home.service.d/
+
 mkdir -p %{buildroot}/%{_docdir}/%{name}-%{version}
 install -m644 -t %{buildroot}/%{_docdir}/%{name}-%{version} Changelog doc/*
 
@@ -148,6 +152,7 @@ install -m644 -t %{buildroot}/%{_docdir}/%{name}-%{version} Changelog doc/*
 %{_sbindir}/quotacheck
 %{_sbindir}/quotaon
 %{_sbindir}/quotaoff
+%{_unitdir}/quota@home.service.d/01-start-before-services.conf
 
 %files nld
 %license COPYING


### PR DESCRIPTION
Systemd waits for the finish of quotacheck (since it does not report back to systemd) and as an post exec sets quota on. As quotacheck sets the fs to readonly it is imperative to start the services, which are expected to have write access to home after this service.